### PR TITLE
setting bodyFieldsOnly to False

### DIFF
--- a/netsuitesdk/internal/client.py
+++ b/netsuitesdk/internal/client.py
@@ -84,9 +84,9 @@ class NetSuiteClient:
         self._is_authenticated = False
         self.set_search_preferences()
 
-    def set_search_preferences(self, body_fields_only: bool = True, page_size: int = 5, return_search_columns: bool = False):
+    def set_search_preferences(self, page_size: int = 5, return_search_columns: bool = False):
         self._search_preferences = self.SearchPreferences(
-            bodyFieldsOnly=body_fields_only,
+            bodyFieldsOnly=False,
             pageSize=page_size,
             returnSearchColumns=return_search_columns
         )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='netsuitesdk',
-    version='1.2.0',
+    version='1.2.1',
     author='Siva Narayanan',
     author_email='siva@fyle.in',
     description='Python SDK for accessing the NetSuite SOAP webservice',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='netsuitesdk',
-    version='1.2.1',
+    version='1.3.0',
     author='Siva Narayanan',
     author_email='siva@fyle.in',
     description='Python SDK for accessing the NetSuite SOAP webservice',


### PR DESCRIPTION
Notes - 

When fetching any of the NetSuite objects, we don't have any values for key `subsidiaryList` in the response
This change will return `subsidiaryList` in response so that we can find out which subsidiary does this object belongs to

Eg - 
locations = nc.locations.get_all()
```
"subsidiaryList": {
        "recordRef": [
          {
            "name": null,
            "internalId": "1",
            "externalId": null,
            "type": null
          }
        ]
      }
```