### PR TITLE
Ability to set customFieldList for transaction body &  specify cache settings to NetSuiteClient

### DIFF
--- a/netsuitesdk/__init__.py
+++ b/netsuitesdk/__init__.py
@@ -3,7 +3,7 @@ from .internal.exceptions import *
 
 
 __all__ = [
-    'NetSuiteConnection'
+    'NetSuiteConnection',
     'NetSuiteError',
     'NetSuiteLoginError',
     'NetSuiteRequestError',

--- a/netsuitesdk/api/journal_entries.py
+++ b/netsuitesdk/api/journal_entries.py
@@ -74,6 +74,29 @@ class JournalEntries(ApiBase):
         if 'department' in data:
             je['department'] = data['department']
 
+        if 'customFieldList' in data:
+            custom_fields = []
+            for field in data['customFieldList']:
+                if field['type'] == 'String':
+                    custom_fields.append(
+                        self.ns_client.client.StringCustomFieldRef(
+                            scriptId=field['scriptId'] if 'scriptId' in field else None,
+                            internalId=field['internalId'] if 'internalId' in field else None,
+                            value=field['value']
+                        )
+                    )
+                elif field['type'] == 'Select':
+                    custom_fields.append(
+                        self.ns_client.client.SelectCustomFieldRef(
+                            scriptId=field['scriptId'] if 'scriptId' in field else None,
+                            internalId=field['internalId'] if 'internalId' in field else None,
+                            value=self.ns_client.client.ListOrRecordRef(
+                                internalId=field['value']
+                            )
+                        )
+                    )
+            je['customFieldList'] = self.ns_client.client.CustomFieldList(custom_fields)
+
         logger.debug('able to create je = %s', je)
         res = self.ns_client.upsert(je)
         return self._serialize(res)

--- a/netsuitesdk/api/journal_entries.py
+++ b/netsuitesdk/api/journal_entries.py
@@ -79,7 +79,7 @@ class JournalEntries(ApiBase):
             for field in data['customFieldList']:
                 if field['type'] == 'String':
                     custom_fields.append(
-                        self.ns_client.client.StringCustomFieldRef(
+                        self.ns_client.StringCustomFieldRef(
                             scriptId=field['scriptId'] if 'scriptId' in field else None,
                             internalId=field['internalId'] if 'internalId' in field else None,
                             value=field['value']
@@ -87,15 +87,15 @@ class JournalEntries(ApiBase):
                     )
                 elif field['type'] == 'Select':
                     custom_fields.append(
-                        self.ns_client.client.SelectCustomFieldRef(
+                        self.ns_client.SelectCustomFieldRef(
                             scriptId=field['scriptId'] if 'scriptId' in field else None,
                             internalId=field['internalId'] if 'internalId' in field else None,
-                            value=self.ns_client.client.ListOrRecordRef(
+                            value=self.ns_client.ListOrRecordRef(
                                 internalId=field['value']
                             )
                         )
                     )
-            je['customFieldList'] = self.ns_client.client.CustomFieldList(custom_fields)
+            je['customFieldList'] = self.ns_client.CustomFieldList(custom_fields)
 
         logger.debug('able to create je = %s', je)
         res = self.ns_client.upsert(je)

--- a/netsuitesdk/connection.py
+++ b/netsuitesdk/connection.py
@@ -19,8 +19,16 @@ from .internal.client import NetSuiteClient
 
 
 class NetSuiteConnection:
-    def __init__(self, account, consumer_key, consumer_secret, token_key, token_secret):
-        ns_client = NetSuiteClient(account=account)
+    def __init__(self, account, consumer_key, consumer_secret, token_key, token_secret, cache_settings=None):
+        """
+        :param str account: The account ID
+        :param str consumer_key: Netsuite Consumer Key
+        :param str consumer_secret: Netsuite Consumer Secret
+        :param str token_key: Netsuite Token Key
+        :param str token_secret: Netsuite Token Secret
+        :param dict cache_settings: Cache Settings for NetSuiteClient
+        """
+        ns_client = NetSuiteClient(account=account, caching=cache_settings)
         ns_client.connect_tba(
             consumer_key=consumer_key,
             consumer_secret=consumer_secret,


### PR DESCRIPTION
This pull request includes just improvements and not new features

1. Added the ability to set customFieldList on transaction body level.
2. We can pass cache settings while initiate the NetSuiteClient class in order to be able dynamically set if cache should be used or not, what kind of engine i want, the path and the timeout. The main reason of adding this is because I was running the sdk in a platform that don't support Sqlite and somehow i wanted to disable the cache.

