### PR TITLE
Adding TransactionSearchAdvanced

### DIFF
--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -87,7 +87,8 @@ COMPLEX_TYPES = {
         'Invoice',
         'InvoiceItem',
         'InvoiceItemList',
-        'TransactionSearch'
+        'TransactionSearch',
+        'TransactionSearchAdvanced',
     ],
 
     # urn:purchases_2017_2.transactions.webservices.netsuite.com


### PR DESCRIPTION
Adding `TransactionSearchAdvanced` to allow calling a saved search.

```python
nc = NetSuiteConnection(...)

transaction_search = nc.client.TransactionSearchAdvanced(savedSearchScriptId="customsearch123")
print(nc.client.search(transaction_search))

```