### PR TITLE
Adding support for CreditMemo

### DIFF
--- a/netsuitesdk/api/credit_memos.py
+++ b/netsuitesdk/api/credit_memos.py
@@ -1,0 +1,129 @@
+from collections import OrderedDict
+
+from .base import ApiBase
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CreditMemos(ApiBase):
+    SIMPLE_FIELDS = [
+        'accountingBookDetailList',
+        'altHandlingCost',
+        'altShippingCost',
+        'amountPaid',
+        'amountRemaining',
+        'applied',
+        'applyList',
+        'autoApply',
+        'balance',
+        'billingAddress',
+        'contribPct',
+        'createdDate',
+        'currencyName',
+        'customFieldList',
+        'deferredRevenue',
+        'discountRate',
+        'discountTotal',
+        'email',
+        'estGrossProfit',
+        'estGrossProfitPercent',
+        'exchangeRate',
+        'excludeCommission',
+        'fax',
+        'giftCertApplied',
+        'giftCertAvailable',
+        'giftCertTotal',
+        'handlingCost',
+        'handlingTax1Rate',
+        'handlingTax2Rate',
+        'internalId',
+        'isMultiShipTo',
+        'isTaxable',
+        'itemList',
+        'lastModifiedDate',
+        'memo',
+        'message',
+        'onCreditHold',
+        'otherRefNum',
+        'partnersList',
+        'recognizedRevenue',
+        'revRecOnRevCommitment',
+        'revenueStatus',
+        'salesEffectiveDate',
+        'salesTeamList',
+        'shippingCost',
+        'shippingTax1Rate',
+        'shippingTax2Rate',
+        'source',
+        'status',
+        'subTotal',
+        'syncPartnerTeams',
+        'syncSalesTeams',
+        'tax2Total',
+        'taxDetailsList',
+        'taxDetailsOverride',
+        'taxPointDate',
+        'taxRate',
+        'taxRegOverride',
+        'taxTotal',
+        'toBeEmailed',
+        'toBeFaxed',
+        'toBePrinted',
+        'total',
+        'totalCostEstimate',
+        'tranDate',
+        'tranId',
+        'tranIsVsoeBundle',
+        'unapplied',
+        'vatRegNum',
+        'vsoeAutoCalc',
+        'nullFieldList',
+    ]
+
+    RECORD_REF_FIELDS = [
+        'account',
+        'billAddressList',
+        'class',
+        'createdFrom',
+        'currency',
+        'customForm',
+        'department',
+        'discountItem',
+        'entityTaxRegNum',
+        'giftCert',
+        'handlingTaxCode',
+        'job',
+        'leadSource',
+        'location',
+        'messageSel',
+        'nexus',
+        'partner',
+        'postingPeriod',
+        'promoCode',
+        'salesGroup',
+        'salesRep',
+        'shipMethod',
+        'shippingTaxCode',
+        'subsidiary',
+        'subsidiaryTaxRegNum',
+        'taxItem',
+    ]
+
+    def __init__(self, ns_client):
+        ApiBase.__init__(self, ns_client=ns_client, type_name='CreditMemo')
+
+    def post(self, data) -> OrderedDict:
+        assert data['externalId'], 'missing external id'
+        credit_memo = self.ns_client.CreditMemo(**data)
+
+        credit_memo['entity'] = self.ns_client.RecordRef(**(data['entity']))
+
+        self.build_simple_fields(self.SIMPLE_FIELDS, data, credit_memo)
+
+        self.build_record_ref_fields(self.RECORD_REF_FIELDS, data, credit_memo)
+
+        logger.debug('able to create credit memo = %s', credit_memo)
+
+        res = self.ns_client.upsert(credit_memo)
+        return self._serialize(res)

--- a/netsuitesdk/connection.py
+++ b/netsuitesdk/connection.py
@@ -1,5 +1,6 @@
 from .api.accounts import Accounts
 from .api.classifications import Classifications
+from .api.credit_memos import CreditMemos
 from .api.departments import Departments
 from .api.currencies import Currencies
 from .api.locations import Locations
@@ -61,3 +62,4 @@ class NetSuiteConnection:
         self.invoices = Invoices(ns_client)
         self.terms = Terms(ns_client)
         self.tax_items = TaxItems(ns_client)
+        self.credit_memos = CreditMemos(ns_client)

--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -108,6 +108,14 @@ COMPLEX_TYPES = {
         'VendorPaymentApply'
     ],
 
+    'ns23': [
+        'CreditMemo',
+        'CreditMemoApply',
+        'CreditMemoApplyList',
+        'CreditMemoItem',
+        'CreditMemoItemList',
+    ],
+
     # urn:general_2019_2.transactions.webservices.netsuite.com
     # https://webservices.netsuite.com/xsd/transactions/v2019_2_0/general.xsd
     'ns31': [


### PR DESCRIPTION
## How to use it?


```python
connection = NetSuiteConnection(
        account="",
        consumer_key="",
        consumer_secret="",
        token_key="",
        token_secret="",
)

items = [
    connection.client.CreditMemoItem(amount=10.00, quantity=1, item={"externalId": ""}),
    connection.client.CreditMemoItem(amount=20.00, quantity=1, item={"externalId": ""}),
]

data = {
    "externalId": "",
    "subsidiary": {"internalId": ""},
    "entity": {"externalId": ""},
    "itemList": connection.client.CreditMemoItemList(item=items)
}
result = connection.credit_memos.post(data)
print(result)

```