### PR TITLE
Adding support for VendorCredits

### DIFF
--- a/netsuitesdk/api/vendor_credits.py
+++ b/netsuitesdk/api/vendor_credits.py
@@ -1,0 +1,71 @@
+from collections import OrderedDict
+
+from .base import ApiBase
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class VendorCredits(ApiBase):
+    SIMPLE_FIELDS = [
+        'accountingBookDetailList',
+        'applied',
+        'applyList',
+        'autoApply',
+        'billingAddress',
+        'createdDate',
+        'currencyName',
+        'customFieldList',
+        'exchangeRate',
+        'expenseList',
+        'internalId',
+        'itemList',
+        'lastModifiedDate',
+        'memo',
+        'taxDetailsList',
+        'taxDetailsOverride',
+        'taxPointDate',
+        'taxRegOverride',
+        'total',
+        'tranDate',
+        'tranId',
+        'transactionNumber',
+        'unApplied',
+        'userTaxTotal',
+        'userTotal',
+        'nullFieldList',
+    ]
+
+    RECORD_REF_FIELDS = [
+        'account',
+        'billAddressList',
+        'class',
+        'createdFrom',
+        'currency',
+        'customForm',
+        'department',
+        'entityTaxRegNum',
+        'location',
+        'nexus',
+        'postingPeriod',
+        'subsidiary',
+        'subsidiaryTaxRegNum',
+    ]
+
+    def __init__(self, ns_client):
+        ApiBase.__init__(self, ns_client=ns_client, type_name='VendorCredit')
+
+    def post(self, data) -> OrderedDict:
+        assert data['externalId'], 'missing external id'
+        vendor_credit = self.ns_client.VendorCredit(**data)
+
+        vendor_credit['entity'] = self.ns_client.RecordRef(**(data['entity']))
+
+        self.build_simple_fields(self.SIMPLE_FIELDS, data, vendor_credit)
+
+        self.build_record_ref_fields(self.RECORD_REF_FIELDS, data, vendor_credit)
+
+        logger.debug('able to create vendor credit = %s', vendor_credit)
+
+        res = self.ns_client.upsert(vendor_credit)
+        return self._serialize(res)

--- a/netsuitesdk/connection.py
+++ b/netsuitesdk/connection.py
@@ -5,6 +5,7 @@ from .api.departments import Departments
 from .api.currencies import Currencies
 from .api.locations import Locations
 from .api.vendor_bills import VendorBills
+from .api.vendor_credits import VendorCredits
 from .api.vendors import Vendors
 from .api.subsidiaries import Subsidiaries
 from .api.journal_entries import JournalEntries
@@ -45,6 +46,7 @@ class NetSuiteConnection:
         self.currencies = Currencies(ns_client)
         self.locations = Locations(ns_client)
         self.vendor_bills = VendorBills(ns_client)
+        self.vendor_credits = VendorCredits(ns_client)
         self.vendors = Vendors(ns_client)
         self.subsidiaries = Subsidiaries(ns_client)
         self.journal_entries = JournalEntries(ns_client)

--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -67,6 +67,10 @@ COMPLEX_TYPES = {
         'ClassificationSearchBasic',
     ],
 
+    'ns6': [
+      'ItemCostEstimateType',
+    ],
+
     # urn:relationships.lists.webservices.netsuite.com
     'ns13': [
         'CustomerAddressbook', 'CustomerAddressbookList',
@@ -109,6 +113,13 @@ COMPLEX_TYPES = {
         'VendorBillExpenseList',
         'VendorBillItem',
         'VendorBillItemList',
+        'VendorCredit',
+        'VendorCreditApply',
+        'VendorCreditApplyList',
+        'VendorCreditExpense',
+        'VendorCreditExpenseList',
+        'VendorCreditItem',
+        'VendorCreditItemList',
         'VendorPayment',
         'VendorPaymentApplyList',
         'VendorPaymentCredit',


### PR DESCRIPTION
## How to use it?

```python
connection = NetSuiteConnection(
        account="",
        consumer_key="",
        consumer_secret="",
        token_key="",
        token_secret="",
)

items = [
    connection.client.VendorCreditItem(amount=10.00, quantity=1, item={"externalId": ""}),
    connection.client.VendorCreditItem(amount=20.00, quantity=1, item={"externalId": ""}),
]

data = {
    "externalId": "",
    "subsidiary": {"internalId": ""},
    "entity": {"externalId": ""},
    "itemList": connection.client.VendorCreditItemList(item=items)
}
result = connection.vendor_credits.post(data)
print(result)

```