### PR TITLE
Add BooleanCustomFieldRef

### DIFF
--- a/netsuitesdk/internal/netsuite_types.py
+++ b/netsuitesdk/internal/netsuite_types.py
@@ -29,6 +29,7 @@ COMPLEX_TYPES = {
         'CustomFieldList',
         'DoubleCustomFieldRef',
         'StringCustomFieldRef',
+        'BooleanCustomFieldRef',
         'CustomRecordRef',
         'SelectCustomFieldRef'
     ],


### PR DESCRIPTION
This PR adds the `BooleanCustomFieldRef` type.

Testing done: it appears to work correctly when updating a record with a boolean custom field.