### PR TITLE
Fixing tabulation on Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,9 +15,9 @@ help:
 .PHONY: help Makefile
 
 buildapi:
-    sphinx-apidoc -fMeT ../netsuitesdk -o _api
-    @echo "Auto-generation of API documentation finished. " \
-          "The generated files are in '_api/'"
+	sphinx-apidoc -fMeT ../netsuitesdk -o _api
+	@echo "Auto-generation of API documentation finished. " \
+	      "The generated files are in '_api/'"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
As indicated by the issue #79 the documentation generation was failing on linux systems.
That is because a [tab character is required](https://www.gnu.org/software/make/manual/make.html#Rule-Introduction) at the beginning of each recipe line.
The file was using withe spaces instead of tabs.