### PR TITLE
Safely access recordList.record in searchMoreWithId()

### DIFF
--- a/netsuitesdk/internal/client.py
+++ b/netsuitesdk/internal/client.py
@@ -495,8 +495,13 @@ class NetSuiteClient:
         status = result.status
         success = status.isSuccess
         if success:
-            result.records = result.recordList.record
-            return result
+            if hasattr(result.recordList, 'record'):
+                result.records = result.recordList.record
+                return result
+            else:
+                # Did not find anything
+                result.records = None
+                return result
         else:
             exc = self._request_error('searchMoreWithId', detail=status['statusDetail'][0])
             raise exc


### PR DESCRIPTION
When attempting to utilize the `searchMoreWithId` function, my team ran into issues with an unsafe access of the `record` property. It seems like in at least some cases, `record` is not returned in the `recordList` property.

The `search` function seems to have implemented this safe access long ago!

For context, here's a redacted snippet of our usage right now. We're hitting a saved search and then paginating through.

```
        searchId = None
        pageIndex = 1

        while True:
            if searchId is None:
                # Fetching and executing a Netsuite saved search
                saved_search = nc.client.TransactionSearchAdvanced(savedSearchId="SOME_ARBITRARY_ID")
                search_result = nc.client.search(saved_search)
                searchId = search_result.searchId
            else:
                # Fetch more results using the searchId
                search_result = nc.client.searchMoreWithId(
                    searchId=searchId, pageIndex=pageIndex
                )

            search_dict = search_result.__json__()

            for row in search_dict["searchRowList"]["searchRow"]:
              # do some stuff with the results

            pageIndex = search_result.pageIndex + 1

            if pageIndex >= search_result.totalPages:
                break

        return order_numbers
```